### PR TITLE
1.21.3 build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.9-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.16.9
 fabric_version=0.110.0+1.21.3
 
 # Mod Properties
-mod_version=1.2.4
+mod_version=1.2.5
 maven_group=xyz.imcodist.quickmenu
 archives_base_name=quick-menu
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21
-yarn_mappings=1.21+build.2
-loader_version=0.15.11
+minecraft_version=1.21.3
+yarn_mappings=1.21.3+build.2
+loader_version=0.16.9
 
 # Fabric API
-fabric_version=0.100.3+1.21
+fabric_version=0.110.0+1.21.3
 
 # Mod Properties
 mod_version=1.2.4
@@ -17,4 +17,4 @@ maven_group=xyz.imcodist.quickmenu
 archives_base_name=quick-menu
 
 # owo-lib
-owo_version=0.12.10+1.21
+owo_version=0.12.18+1.21.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/xyz/imcodist/quickmenu/ui/surfaces/SwitcherSurface.java
+++ b/src/main/java/xyz/imcodist/quickmenu/ui/surfaces/SwitcherSurface.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import io.wispforest.owo.ui.core.OwoUIDrawContext;
 import io.wispforest.owo.ui.core.ParentComponent;
 import io.wispforest.owo.ui.core.Surface;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.util.Identifier;
 
 public class SwitcherSurface implements Surface {
@@ -58,7 +59,7 @@ public class SwitcherSurface implements Surface {
     }
 
     public void drawTexture(OwoUIDrawContext context, int x, int y, int sourceX, int sourceY, int sourceWidth, int sourceHeight, int textureWidth, int textureHeight) {
-        context.drawTexture(Identifier.of("quickmenu", "textures/switcher_textures.png"), x, y, sourceX, sourceY, sourceWidth, sourceHeight, textureWidth, textureHeight);
+        context.drawTexture(RenderLayer::getGuiTexturedOverlay, Identifier.of("quickmenu", "textures/switcher_textures.png"), x, y, sourceX, sourceY, sourceWidth, sourceHeight, textureWidth, textureHeight);
     }
 
     public void drawRepeatingTexture(OwoUIDrawContext context, int x, int y, int sourceX, int sourceY, int sourceWidth, int sourceHeight, int textureWidth, int textureHeight, int width, int height) {


### PR DESCRIPTION
Fixes a change with the `net.minecraft.client.gui.DrawContext:drawTexture(...)` method where it now requires a function to provide a `RenderLayer` as a parameter.

Trial and error has shown `RenderLayer::getGuiTexturedOverlay` to be the correct parameter value, others caused background texture of the overlay to be a white square instead.