### PR TITLE
Update for 1.21.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.9-SNAPSHOT'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,17 +4,17 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.10
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
+loader_version=0.16.13
 
 # Fabric API
-fabric_version=0.115.1+1.21.4
+fabric_version=0.121.0+1.21.5
 
 # Mod Properties
-mod_version=1.2.6
+mod_version=1.2.7
 maven_group=xyz.imcodist.quickmenu
 archives_base_name=quick-menu
 
 # owo-lib
-owo_version=0.12.20+1.21.4
+owo_version=0.12.20+1.21.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/xyz/imcodist/quickmenu/ui/surfaces/SwitcherSurface.java
+++ b/src/main/java/xyz/imcodist/quickmenu/ui/surfaces/SwitcherSurface.java
@@ -1,7 +1,7 @@
 package xyz.imcodist.quickmenu.ui.surfaces;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.opengl;
+import com.mojang.blaze3d.opengl.GlStateManager;
 import io.wispforest.owo.ui.core.OwoUIDrawContext;
 import io.wispforest.owo.ui.core.ParentComponent;
 import io.wispforest.owo.ui.core.Surface;

--- a/src/main/java/xyz/imcodist/quickmenu/ui/surfaces/SwitcherSurface.java
+++ b/src/main/java/xyz/imcodist/quickmenu/ui/surfaces/SwitcherSurface.java
@@ -1,6 +1,7 @@
 package xyz.imcodist.quickmenu.ui.surfaces;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.opengl;
 import io.wispforest.owo.ui.core.OwoUIDrawContext;
 import io.wispforest.owo.ui.core.ParentComponent;
 import io.wispforest.owo.ui.core.Surface;
@@ -25,14 +26,14 @@ public class SwitcherSurface implements Surface {
         int sourceX = (isHeader) ? 0 : 24;
 
         // Make sure the background renders as transparent.
-        if (!isHeader) RenderSystem.enableBlend();
+        if (!isHeader) GlStateManager._enableBlend();
         RenderSystem.setShaderColor(1, 1, 1, 1);
 
         // Draws the texture as a 9 slice.
         drawNineSlicedTexture(context, x, y, width, height, sourceX, 0, 6, 6, 12, 12, 52, 50);
 
         // Undo previous render system changes.
-        if (!isHeader) RenderSystem.disableBlend();
+        if (!isHeader) GlStateManager._disableBlend();
         RenderSystem.setShaderColor(1, 1, 1, 1);
     }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,8 +29,8 @@
 		"quickmenu.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.16.10",
-		"minecraft": "=1.21.4",
+		"fabricloader": ">=0.16.13",
+		"minecraft": "=1.21.5",
 		"java": ">=21",
 		"fabric-api": "*",
 


### PR DESCRIPTION
Nothing to report, except for `RenderSystem.enableBlend()` and `RenderSystem.disableBlend()` being removed (see https://github.com/neoforged/.github/blob/main/primers/1.21.5/index.md). Tested on Fabric 0.16.14.